### PR TITLE
Upgrading Guava to 20.0

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/Journal.java
@@ -813,9 +813,10 @@ class Journal extends BookieCriticalThread implements CheckpointSource {
         ZeroBuffer.put(paddingBuff);
         JournalChannel logFile = null;
         forceWriteThread.start();
-        Stopwatch journalAllocationWatcher = new Stopwatch();
-        Stopwatch journalCreationWatcher = new Stopwatch();
-        Stopwatch journalFlushWatcher = new Stopwatch();
+        Stopwatch journalAllocationWatcher = Stopwatch.createUnstarted();
+        Stopwatch journalCreationWatcher = Stopwatch.createUnstarted();
+        Stopwatch journalFlushWatcher = Stopwatch.createUnstarted();
+
         long batchSize = 0;
         try {
             List<Long> journalIds = listJournalIds(journalDirectory, null);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/ReplicationWorker.java
@@ -205,7 +205,7 @@ public class ReplicationWorker implements Runnable {
         long ledgerIdToReplicate = underreplicationManager
                 .getLedgerToRereplicate();
 
-        Stopwatch stopwatch = new Stopwatch().start();
+        Stopwatch stopwatch = Stopwatch.createStarted();
         boolean success = false;
         try {
             success = rereplicate(ledgerIdToReplicate);

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <!-- ProtocolBuffer version -->
     <protobuf.version>2.4.1</protobuf.version>
     <!-- Guava Version -->
-    <guava.version>16.0</guava.version>
+    <guava.version>20.0</guava.version>
     <netty.version>3.9.4.Final</netty.version>
     <zookeeper.version>3.5.1-alpha</zookeeper.version>
   </properties>


### PR DESCRIPTION
This change is required for fixing the issue https://issues.apache.org/jira/browse/DL-193. This increases the Guava version to 20.0 and uses the updated APIs.